### PR TITLE
User capabilities check during token validation

### DIFF
--- a/inc/class-token.php
+++ b/inc/class-token.php
@@ -5,6 +5,7 @@ namespace Bluehost\Maestro;
 use Exception;
 use Firebase\JWT\JWT;
 use WP_Error;
+use WP_User;
 
 /**
  * Class for creating and validating BH Maestro JSON web tokens for authentication
@@ -193,6 +194,14 @@ class Token {
 			return new WP_Error(
 				'invalid_token_webpro',
 				__( 'Web Pro is invalid.' ),
+			);
+		}
+
+		// Confirm user has Admin capabilities
+		if ( $this->webpro->user instanceof WP_User && ! $this->webpro->user->has_cap( 'manage_options' ) ) {
+			return new WP_Error(
+				'invalid_user_capabilities',
+				__( 'User lacks administrative capabilities.' )
 			);
 		}
 


### PR DESCRIPTION
I reviewed the auth flow and everything looks secure, but this would deny login to the subscriber account. 

If another plugin developer does bad capabilities check (i.e. `is_admin()`) and someone can login even as a subscriber, that could create an undesired scenario 🙈 

Please ignore if this was done some other way or you think not necessary 🤷‍♂ 