### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ permissions: {}
 jobs:
   phpcs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read # Required to check out the repository.
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,15 @@ on:
     paths:
       - '**.php'
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to check out the repository.
     steps:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -13,6 +13,7 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions: {} # No GITHUB_TOKEN access needed; repository-dispatch uses a separate WEBHOOK_TOKEN secret targeting another repository.
     steps:
 

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # No GITHUB_TOKEN access needed; repository-dispatch uses a separate WEBHOOK_TOKEN secret targeting another repository.
     steps:
 
       - name: Set Package

--- a/.github/workflows/svn-deploy-assets-on-push.yml
+++ b/.github/workflows/svn-deploy-assets-on-push.yml
@@ -15,6 +15,7 @@ jobs:
   master:
     name: Push to master
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read # Required to check out the repository. The asset updater pushes to WordPress.org SVN using SVN_USERNAME/SVN_PASSWORD secrets (no GitHub API usage).
     steps:

--- a/.github/workflows/svn-deploy-assets-on-push.yml
+++ b/.github/workflows/svn-deploy-assets-on-push.yml
@@ -6,10 +6,17 @@ on:
     paths:
       - .wordpress-org/*
       - readme.txt
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   master:
     name: Push to master
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to check out the repository. The asset updater pushes to WordPress.org SVN using SVN_USERNAME/SVN_PASSWORD secrets (no GitHub API usage).
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: WordPress.org plugin asset/readme update

--- a/.github/workflows/svn-deploy-plugin-on-release.yml
+++ b/.github/workflows/svn-deploy-plugin-on-release.yml
@@ -4,10 +4,17 @@ on:
     types:
       - created
       - edited
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   tag:
     name: New tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to check out the repository. The plugin deploy action publishes to WordPress.org SVN using SVN_USERNAME/SVN_PASSWORD secrets (no GitHub API usage).
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build

--- a/.github/workflows/svn-deploy-plugin-on-release.yml
+++ b/.github/workflows/svn-deploy-plugin-on-release.yml
@@ -13,6 +13,7 @@ jobs:
   tag:
     name: New tag
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # Required to check out the repository. The plugin deploy action publishes to WordPress.org SVN using SVN_USERNAME/SVN_PASSWORD secrets (no GitHub API usage).
     steps:

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: On Push to Master
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # Required to check out the repository. actions/upload-artifact uses the Actions runtime API (not GITHUB_TOKEN) and needs no additional scopes.
     steps:

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -5,10 +5,16 @@ on:
     branches:
       - master
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   build:
     name: On Push to Master
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to check out the repository. actions/upload-artifact uses the Actions runtime API (not GITHUB_TOKEN) and needs no additional scopes.
     steps:
 
       - name: Checkout

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     name: On Release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write # Required by actions/upload-release-asset to upload the built zip to the GitHub release via the Releases API.
     steps:

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -6,10 +6,16 @@ on:
       - created
       - updated
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   build:
     name: On Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required by actions/upload-release-asset to upload the built zip to the GitHub release via the Releases API.
     steps:
 
       - name: Checkout


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/newfold-labs/maestro-connector/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 6 (`lint.yml`, `satis-webhook.yml`, `svn-deploy-assets-on-push.yml`, `svn-deploy-plugin-on-release.yml`, `upload-artifact-on-push.yml`, `upload-asset-on-release.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `e78ee0b` |
| Timeouts commit | `7d3fe9b` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-webhook.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `svn-deploy-assets-on-push.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `svn-deploy-plugin-on-release.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `upload-artifact-on-push.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `upload-asset-on-release.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read` [3] |
| satis-webhook.yml | 1 job was missing a scoped `permissions:` directive | webhook | `{}` (no GITHUB_TOKEN access needed; `peter-evans/repository-dispatch` uses a separate `WEBHOOK_TOKEN` PAT to dispatch to `bluehost/satis`) [3] |
| svn-deploy-assets-on-push.yml | 1 job was missing a scoped `permissions:` directive | master | `contents: read` (checkout only; `bluehost/wp-plugin-readme-assets-updater` is a Docker action that pushes to WordPress.org SVN with `SVN_USERNAME`/`SVN_PASSWORD` and does not call the GitHub API) [3] |
| svn-deploy-plugin-on-release.yml | 1 job was missing a scoped `permissions:` directive | tag | `contents: read` (checkout only; `10up/action-wordpress-plugin-deploy` deploys to WordPress.org SVN using SVN credentials and does not use `GITHUB_TOKEN`) [3] |
| upload-artifact-on-push.yml | 1 job was missing a scoped `permissions:` directive | build | `contents: read` (checkout only; `actions/upload-artifact@v4` uploads via the Actions runtime artifact API, which does not consume `GITHUB_TOKEN` permission scopes) [3] |
| upload-asset-on-release.yml | 1 job was missing a scoped `permissions:` directive | build | `contents: write` (`actions/upload-release-asset@v1` uploads release assets via the Releases API using `GITHUB_TOKEN`, which requires write access to repository contents/releases) [3] |


## Permissions corrections (previously incorrect)

No pre-existing configured `permissions:` were identified as incorrect.

## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| lint.yml | phpcs | `15` | PHPCS over the plugin's PHP files plus Composer cache restore typically completes in a few minutes; 15 leaves headroom for cold caches. |
| satis-webhook.yml | webhook | `5` | Job only sets two outputs and fires a single `repository-dispatch` HTTP request, so a tight 5-minute cap prevents runaway use. |
| svn-deploy-assets-on-push.yml | master | `15` | A small docker-based SVN push of `.wordpress-org/*` and `readme.txt`; 15 minutes covers Docker image pull plus SVN commit. |
| svn-deploy-plugin-on-release.yml | tag | `30` | Includes a full `composer install --no-dev` build followed by an SVN deploy to wp.org; 30 minutes is the standard ceiling for plugin release pipelines. |
| upload-artifact-on-push.yml | build | `30` | Runs npm install, i18n generation, composer install, cleanup, and artifact upload; 30 minutes accommodates cache misses. |
| upload-asset-on-release.yml | build | `30` | Same build pipeline as the push artifact workflow plus zip creation and release-asset upload; 30 minutes matches. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `bluehost/wp-plugin-readme-assets-updater@master` is pinned to a moving `master` ref (not a SHA). Its `action.yml` is a Docker action with no GitHub API inputs, so `contents: read` is sufficient based on current behavior, but unpinned third-party Docker images warrant a separate hardening pass. |
| 2 | `actions/upload-release-asset@v1` is archived/deprecated by GitHub. The repo may want to migrate to `softprops/action-gh-release` or `gh release upload`, but that is out of scope for this audit; `contents: write` remains the correct minimum scope for the current action. |
| 3 | Branch `add/scoped-workflow-permissions` was created locally and committed but intentionally not pushed, per instructions. |


